### PR TITLE
Tests

### DIFF
--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -15,8 +15,9 @@ describe("Getting the correct change in return.", () => {
     //////////// 28 Cents //////////////
     it("Should return 2 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(28)
-        expect(result.dimes).toBe(2)
-        expect(result.nickels).toBe(1)
+        expect(result.quarters).toBe(1)
+        expect(result.dimes).toBe(0)
+        expect(result.nickels).toBe(0)
         expect(result.pennies).toBe(3)
     })
 

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -18,8 +18,9 @@ describe("Getting the correct change in return.", () => {
         })
 
     //////////// FIFTY DOLLAR BILLS & BELOW //////////////
-    it("Should return 1 fifty dollar bill, 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
+    it("Should return 0 one hundred dollar bills, 1 fifty dollar bill, 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(8267)
+        expect(result.oneHundredDollarBills).toBe(0)
         expect(result.fiftyDollarBills).toBe(1)
         expect(result.twentyDollarBills).toBe(1)
         expect(result.tenDollarBills).toBe(1)
@@ -31,8 +32,9 @@ describe("Getting the correct change in return.", () => {
         })
 
     //////////// TWENTY DOLLAR BILLS & BELOW //////////////
-    it("Should return 0 fifty dollar bills, 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
+    it("Should return 0 one hundred dollar bills, 0 fifty dollar bills, 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(3267)
+        expect(result.oneHundredDollarBills).toBe(0)
         expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(1)
         expect(result.tenDollarBills).toBe(1)
@@ -44,8 +46,9 @@ describe("Getting the correct change in return.", () => {
         })
 
     //////////// TEN DOLLAR BILLS & BELOW //////////////
-    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 1 ten dollar bill, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
+    it("Should return 0 one hundred dollar bills, 0 fifty dollar bills, 0 twenty dollar bills, 1 ten dollar bill, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(1193)
+        expect(result.oneHundredDollarBills).toBe(0)
         expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(1)
@@ -58,8 +61,9 @@ describe("Getting the correct change in return.", () => {
     
 
     //////////// ONE DOLLAR BILLS & BELOW //////////////
-    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
+    it("Should return 0 one hundred dollar bills, 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(193)
+        expect(result.oneHundredDollarBills).toBe(0)
         expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
@@ -73,8 +77,9 @@ describe("Getting the correct change in return.", () => {
 
     //////////// QUARTERS & BELOW //////////////
 
-    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
+    it("Should return 0 one hundred dollar bills, 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
         const result = returnChange(44)
+        expect(result.oneHundredDollarBills).toBe(0)
         expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
@@ -85,8 +90,9 @@ describe("Getting the correct change in return.", () => {
         expect(result.pennies).toBe(4)
         })
 
-    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
+    it("Should return 0 one hundred dollar bills, 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
         const result = returnChange(28)
+        expect(result.oneHundredDollarBills).toBe(0)
         expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
@@ -98,8 +104,9 @@ describe("Getting the correct change in return.", () => {
     })
 
     //////////// DIMES & BELOW //////////////
-    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 dime, 1 nickel, and 2 pennies.", () => {
+    it("Should return 0 one hundred dollar bills, 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 dime, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(17)
+        expect(result.oneHundredDollarBills).toBe(0)
         expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
@@ -112,8 +119,9 @@ describe("Getting the correct change in return.", () => {
 
 
     ////////////// NICKELS & BELOW //////////////
-    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 nickel and 2 pennies", () => {
+    it("Should return 0 one hundred dollar bills, 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 nickel and 2 pennies", () => {
         const result = returnChange(7)
+        expect(result.oneHundredDollarBills).toBe(0)
         expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
@@ -127,8 +135,9 @@ describe("Getting the correct change in return.", () => {
     
     //////////// PENNIES //////////////
 
-    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 0 quarters, 0 dimes, 0 nickels, and 4 pennies.", () => {
+    it("Should return 0 one hundred dollar bills, 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 0 quarters, 0 dimes, 0 nickels, and 4 pennies.", () => {
         const result = returnChange(4)
+        expect(result.oneHundredDollarBills).toBe(0)
         expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -17,8 +17,9 @@ describe("Getting the correct change in return.", () => {
         })
 
     //////////// TWENTY DOLLAR BILLS & BELOW //////////////
-    it("Should return 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
+    it("Should return 0 fifty dollar bills, 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(3267)
+        expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(1)
         expect(result.tenDollarBills).toBe(1)
         expect(result.oneDollarBills).toBe(2)
@@ -29,8 +30,9 @@ describe("Getting the correct change in return.", () => {
         })
 
     //////////// TEN DOLLAR BILLS & BELOW //////////////
-    it("Should return 0 twenty dollar bills, 1 ten dollar bill, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
+    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 1 ten dollar bill, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(1193)
+        expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(1)
         expect(result.oneDollarBills).toBe(1)
@@ -42,8 +44,9 @@ describe("Getting the correct change in return.", () => {
     
 
     //////////// ONE DOLLAR BILLS & BELOW //////////////
-    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
+    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(193)
+        expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(1)
@@ -56,8 +59,9 @@ describe("Getting the correct change in return.", () => {
 
     //////////// QUARTERS & BELOW //////////////
 
-    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
+    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
         const result = returnChange(44)
+        expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
@@ -67,8 +71,9 @@ describe("Getting the correct change in return.", () => {
         expect(result.pennies).toBe(4)
         })
 
-    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
+    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
         const result = returnChange(28)
+        expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
@@ -79,8 +84,9 @@ describe("Getting the correct change in return.", () => {
     })
 
     //////////// DIMES & BELOW //////////////
-    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 dime, 1 nickel, and 2 pennies.", () => {
+    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 dime, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(17)
+        expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
@@ -92,8 +98,9 @@ describe("Getting the correct change in return.", () => {
 
 
     ////////////// NICKELS & BELOW //////////////
-    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 nickel and 2 pennies", () => {
+    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 nickel and 2 pennies", () => {
         const result = returnChange(7)
+        expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
@@ -106,8 +113,9 @@ describe("Getting the correct change in return.", () => {
     
     //////////// PENNIES //////////////
 
-    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 0 quarters, 0 dimes, 0 nickels, and 4 pennies.", () => {
+    it("Should return 0 fifty dollar bills, 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 0 quarters, 0 dimes, 0 nickels, and 4 pennies.", () => {
         const result = returnChange(4)
+        expect(result.fiftyDollarBills).toBe(0)
         expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -1,0 +1,31 @@
+const returnChange = require("../modules/coinReturns")
+
+
+describe("Getting the correct change in return.", () => {
+
+    ////////////// 22 Cents //////////////
+    it("Should return 2 dimes and 2 pennies.", () => {
+        const result = returnChange(22)
+        expect(result.dimes).toBe(2)
+        expect(result.nickels).toBe(0)
+        expect(result.pennies).toBe(2)
+    })
+
+
+    ////////////// 7 cents //////////////
+    it("Should return 1 nickel and 2 pennies", () => {
+        const result = returnChange(7)
+        expect(result.nickels).toBe(1)
+        expect(result.pennies).toBe(2)
+    })
+
+    
+    //////////// 4 cents //////////////
+
+    it("Should return 4 pennies.", () => {
+        const result = returnChange(4)
+        expect(result.pennies).toBe(4)
+    })
+
+
+})

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -16,8 +16,9 @@ describe("Getting the correct change in return.", () => {
     
 
     //////////// ONE DOLLAR BILLS & BELOW //////////////
-    it("Should return 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
+    it("Should return 0 ten dollar bills, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(193)
+        expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(1)
         expect(result.quarters).toBe(3)
         expect(result.dimes).toBe(1)
@@ -28,8 +29,9 @@ describe("Getting the correct change in return.", () => {
 
     //////////// QUARTERS & BELOW //////////////
 
-    it("Should return 0 one dollar bills, 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
+    it("Should return 0 ten dollar bills, 0 one dollar bills, 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
         const result = returnChange(44)
+        expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(1)
         expect(result.dimes).toBe(1)
@@ -37,8 +39,9 @@ describe("Getting the correct change in return.", () => {
         expect(result.pennies).toBe(4)
         })
 
-    it("Should return 0 one dollar bills, 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
+    it("Should return 0 ten dollar bills, 0 one dollar bills, 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
         const result = returnChange(28)
+        expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(1)
         expect(result.dimes).toBe(0)
@@ -47,8 +50,9 @@ describe("Getting the correct change in return.", () => {
     })
 
     //////////// DIMES & BELOW //////////////
-    it("Should return 0 one dollar bills, 1 dime, 1 nickel, and 2 pennies.", () => {
+    it("Should return 0 ten dollar bills, 0 one dollar bills, 1 dime, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(17)
+        expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)
         expect(result.dimes).toBe(1)
@@ -58,8 +62,9 @@ describe("Getting the correct change in return.", () => {
 
 
     ////////////// NICKELS & BELOW //////////////
-    it("Should return 0 one dollar bills, 1 nickel and 2 pennies", () => {
+    it("Should return 0 ten dollar bills, 0 one dollar bills, 1 nickel and 2 pennies", () => {
         const result = returnChange(7)
+        expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)
         expect(result.dimes).toBe(0)
@@ -72,6 +77,7 @@ describe("Getting the correct change in return.", () => {
 
     it("Should return 0 one dollar bills, 0 quarters, 0 dimes, 0 nickels, and 4 pennies.", () => {
         const result = returnChange(4)
+        expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)
         expect(result.dimes).toBe(0)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -3,6 +3,16 @@ const returnChange = require("../changeReturn")
 
 describe("Getting the correct change in return.", () => {
 
+    //////////// 193 Cents //////////////
+    it("Should return 7 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
+        const result = returnChange(193)
+        expect(result.quarters).toBe(7)
+        expect(result.dimes).toBe(1)
+        expect(result.nickels).toBe(1)
+        expect(result.pennies).toBe(3)
+        })
+    
+
     //////////// 44 Cents //////////////
     it("Should return 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
         const result = returnChange(44)
@@ -21,10 +31,21 @@ describe("Getting the correct change in return.", () => {
         expect(result.pennies).toBe(3)
     })
 
+    //////////// 2 Cents //////////////
+    it("Should return 2 dimes, 1 nickel, and 3 pennies.", () => {
+        const result = returnChange(28)
+        expect(result.quarters).toBe(1)
+        expect(result.dimes).toBe(0)
+        expect(result.nickels).toBe(0)
+        expect(result.pennies).toBe(3)
+    })
+
 
     ////////////// 7 cents //////////////
     it("Should return 1 nickel and 2 pennies", () => {
         const result = returnChange(7)
+        expect(result.quarters).toBe(0)
+        expect(result.dimes).toBe(0)
         expect(result.nickels).toBe(1)
         expect(result.pennies).toBe(2)
     })
@@ -34,6 +55,9 @@ describe("Getting the correct change in return.", () => {
 
     it("Should return 4 pennies.", () => {
         const result = returnChange(4)
+        expect(result.quarters).toBe(0)
+        expect(result.dimes).toBe(0)
+        expect(result.nickels).toBe(0)
         expect(result.pennies).toBe(4)
     })
 

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -3,20 +3,12 @@ const returnChange = require("../changeReturn")
 
 describe("Getting the correct change in return.", () => {
 
-    // //////////// 22 Cents //////////////
-    // it("Should return 2 dimes and 2 pennies.", () => {
-    //     const result = returnChange(22)
-    //     expect(result.dimes).toBe(2)
-    //     expect(result.nickels).toBe(0)
-    //     expect(result.pennies).toBe(2)
-    // })
-
-
-    ////////////// 14 cents //////////////
-    it("Should return 2 nickels and 4 pennies", () => {
-        const result = returnChange(14)
-        expect(result.nickels).toBe(2)
-        expect(result.pennies).toBe(4)
+    //////////// 28 Cents //////////////
+    it("Should return 2 dimes, 1 nickel, and 3 pennies.", () => {
+        const result = returnChange(22)
+        expect(result.dimes).toBe(2)
+        expect(result.nickels).toBe(1)
+        expect(result.pennies).toBe(3)
     })
 
 

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -6,7 +6,7 @@ describe("Getting the correct change in return.", () => {
     //////////// DOLLARS & BELOW //////////////
     it("Should return 7 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(193)
-        expect(result.oneDollarBill).toBe(1)
+        expect(result.oneDollarBills).toBe(1)
         expect(result.quarters).toBe(3)
         expect(result.dimes).toBe(1)
         expect(result.nickels).toBe(1)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -3,6 +3,15 @@ const returnChange = require("../changeReturn")
 
 describe("Getting the correct change in return.", () => {
 
+    //////////// 44 Cents //////////////
+    it("Should return 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
+        const result = returnChange(44)
+        expect(result.quarters).toBe(1)
+        expect(result.dimes).toBe(1)
+        expect(result.nickels).toBe(1)
+        expect(result.pennies).toBe(4)
+        })
+
     //////////// 28 Cents //////////////
     it("Should return 2 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(28)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -3,6 +3,20 @@ const returnChange = require("../changeReturn")
 
 describe("Getting the correct change in return.", () => {
 
+    //////////// ONE HUNDRED DOLLAR BILLS & BELOW //////////////
+    it("Should return 1 one hundred dollar bill, 1 fifty dollar bill, 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
+        const result = returnChange(18267)
+        expect(result.oneHundredDollarBills).toBe(1)
+        expect(result.fiftyDollarBills).toBe(1)
+        expect(result.twentyDollarBills).toBe(1)
+        expect(result.tenDollarBills).toBe(1)
+        expect(result.oneDollarBills).toBe(2)
+        expect(result.quarters).toBe(2)
+        expect(result.dimes).toBe(1)
+        expect(result.nickels).toBe(1)
+        expect(result.pennies).toBe(2)
+        })
+
     //////////// FIFTY DOLLAR BILLS & BELOW //////////////
     it("Should return 1 fifty dollar bill, 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(8267)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -3,6 +3,18 @@ const returnChange = require("../changeReturn")
 
 describe("Getting the correct change in return.", () => {
 
+    //////////// TWENTY DOLLAR BILLS & BELOW //////////////
+    it("Should return 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
+        const result = returnChange(3267)
+        expect(result.twentyDollarBills).toBe(1)
+        expect(result.tenDollarBills).toBe(1)
+        expect(result.oneDollarBills).toBe(2)
+        expect(result.quarters).toBe(2)
+        expect(result.dimes).toBe(1)
+        expect(result.nickels).toBe(1)
+        expect(result.pennies).toBe(2)
+        })
+
     //////////// TEN DOLLAR BILLS & BELOW //////////////
     it("Should return 1 ten dollar bill, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(1193)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -3,21 +3,21 @@ const returnChange = require("../changeReturn")
 
 describe("Getting the correct change in return.", () => {
 
-    //////////// 22 Cents //////////////
-    it("Should return 2 dimes and 2 pennies.", () => {
-        const result = returnChange(22)
-        expect(result.dimes).toBe(2)
-        expect(result.nickels).toBe(0)
-        expect(result.pennies).toBe(2)
-    })
-
-
-    // ////////////// 14 cents //////////////
-    // it("Should return 2 nickels and 4 pennies", () => {
-    //     const result = returnChange(14)
-    //     expect(result.nickels).toBe(2)
-    //     expect(result.pennies).toBe(4)
+    // //////////// 22 Cents //////////////
+    // it("Should return 2 dimes and 2 pennies.", () => {
+    //     const result = returnChange(22)
+    //     expect(result.dimes).toBe(2)
+    //     expect(result.nickels).toBe(0)
+    //     expect(result.pennies).toBe(2)
     // })
+
+
+    ////////////// 14 cents //////////////
+    it("Should return 2 nickels and 4 pennies", () => {
+        const result = returnChange(14)
+        expect(result.nickels).toBe(2)
+        expect(result.pennies).toBe(4)
+    })
 
 
     ////////////// 7 cents //////////////

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -3,12 +3,20 @@ const returnChange = require("../changeReturn")
 
 describe("Getting the correct change in return.", () => {
 
-    ////////////// 22 Cents //////////////
-    // it("Should return 2 dimes and 2 pennies.", () => {
-    //     const result = returnChange(22)
-    //     expect(result.dimes).toBe(2)
-    //     expect(result.nickels).toBe(0)
-    //     expect(result.pennies).toBe(2)
+    //////////// 22 Cents //////////////
+    it("Should return 2 dimes and 2 pennies.", () => {
+        const result = returnChange(22)
+        expect(result.dimes).toBe(2)
+        expect(result.nickels).toBe(0)
+        expect(result.pennies).toBe(2)
+    })
+
+
+    // ////////////// 14 cents //////////////
+    // it("Should return 2 nickels and 4 pennies", () => {
+    //     const result = returnChange(14)
+    //     expect(result.nickels).toBe(2)
+    //     expect(result.pennies).toBe(4)
     // })
 
 
@@ -17,13 +25,6 @@ describe("Getting the correct change in return.", () => {
         const result = returnChange(7)
         expect(result.nickels).toBe(1)
         expect(result.pennies).toBe(2)
-    })
-
-    ////////////// 14 cents //////////////
-    it("Should return 2 nickels and 4 pennies", () => {
-        const result = returnChange(14)
-        expect(result.nickels).toBe(2)
-        expect(result.pennies).toBe(4)
     })
 
     

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -3,15 +3,18 @@ const returnChange = require("../changeReturn")
 
 describe("Getting the correct change in return.", () => {
 
-    //////////// QUARTERS & BELOW //////////////
+    //////////// DOLLARS & BELOW //////////////
     it("Should return 7 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(193)
-        expect(result.quarters).toBe(7)
+        expect(result.oneDollarBill).toBe(1)
+        expect(result.quarters).toBe(3)
         expect(result.dimes).toBe(1)
         expect(result.nickels).toBe(1)
         expect(result.pennies).toBe(3)
         })
-    
+
+
+    //////////// QUARTERS & BELOW //////////////
 
     it("Should return 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
         const result = returnChange(44)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -3,7 +3,7 @@ const returnChange = require("../changeReturn")
 
 describe("Getting the correct change in return.", () => {
 
-    //////////// 193 Cents //////////////
+    //////////// QUARTERS & BELOW //////////////
     it("Should return 7 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(193)
         expect(result.quarters).toBe(7)
@@ -13,7 +13,6 @@ describe("Getting the correct change in return.", () => {
         })
     
 
-    //////////// 44 Cents //////////////
     it("Should return 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
         const result = returnChange(44)
         expect(result.quarters).toBe(1)
@@ -22,8 +21,7 @@ describe("Getting the correct change in return.", () => {
         expect(result.pennies).toBe(4)
         })
 
-    //////////// 28 Cents //////////////
-    it("Should return 2 dimes, 1 nickel, and 3 pennies.", () => {
+    it("Should return 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
         const result = returnChange(28)
         expect(result.quarters).toBe(1)
         expect(result.dimes).toBe(0)
@@ -31,17 +29,17 @@ describe("Getting the correct change in return.", () => {
         expect(result.pennies).toBe(3)
     })
 
-    //////////// 2 Cents //////////////
-    it("Should return 2 dimes, 1 nickel, and 3 pennies.", () => {
-        const result = returnChange(28)
-        expect(result.quarters).toBe(1)
-        expect(result.dimes).toBe(0)
-        expect(result.nickels).toBe(0)
-        expect(result.pennies).toBe(3)
+    //////////// DIMES & BELOW //////////////
+    it("Should return 1 dime, 1 nickel, and 2 pennies.", () => {
+        const result = returnChange(17)
+        expect(result.quarters).toBe(0)
+        expect(result.dimes).toBe(1)
+        expect(result.nickels).toBe(1)
+        expect(result.pennies).toBe(2)
     })
 
 
-    ////////////// 7 cents //////////////
+    ////////////// NICKELS & BELOW //////////////
     it("Should return 1 nickel and 2 pennies", () => {
         const result = returnChange(7)
         expect(result.quarters).toBe(0)
@@ -51,7 +49,7 @@ describe("Getting the correct change in return.", () => {
     })
 
     
-    //////////// 4 cents //////////////
+    //////////// PENNIES //////////////
 
     it("Should return 4 pennies.", () => {
         const result = returnChange(4)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -2,9 +2,10 @@ const returnChange = require("../changeReturn")
 
 
 describe("Getting the correct change in return.", () => {
+    
 
     //////////// DOLLARS & BELOW //////////////
-    it("Should return 7 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
+    it("Should return 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(193)
         expect(result.oneDollarBills).toBe(1)
         expect(result.quarters).toBe(3)
@@ -16,7 +17,7 @@ describe("Getting the correct change in return.", () => {
 
     //////////// QUARTERS & BELOW //////////////
 
-    it("Should return 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
+    it("Should return 0 one dollar bills, 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
         const result = returnChange(44)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(1)
@@ -25,7 +26,7 @@ describe("Getting the correct change in return.", () => {
         expect(result.pennies).toBe(4)
         })
 
-    it("Should return 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
+    it("Should return 0 one dollar bills, 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
         const result = returnChange(28)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(1)
@@ -35,7 +36,7 @@ describe("Getting the correct change in return.", () => {
     })
 
     //////////// DIMES & BELOW //////////////
-    it("Should return 1 dime, 1 nickel, and 2 pennies.", () => {
+    it("Should return 0 one dollar bills, 1 dime, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(17)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)
@@ -46,7 +47,7 @@ describe("Getting the correct change in return.", () => {
 
 
     ////////////// NICKELS & BELOW //////////////
-    it("Should return 1 nickel and 2 pennies", () => {
+    it("Should return 0 one dollar bills, 1 nickel and 2 pennies", () => {
         const result = returnChange(7)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)
@@ -58,7 +59,7 @@ describe("Getting the correct change in return.", () => {
     
     //////////// PENNIES //////////////
 
-    it("Should return 4 pennies.", () => {
+    it("Should return 0 one dollar bills, 0 quarters, 0 dimes, 0 nickels, and 4 pennies.", () => {
         const result = returnChange(4)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -16,8 +16,9 @@ describe("Getting the correct change in return.", () => {
         })
 
     //////////// TEN DOLLAR BILLS & BELOW //////////////
-    it("Should return 1 ten dollar bill, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
+    it("Should return 0 twenty dollar bills, 1 ten dollar bill, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(1193)
+        expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(1)
         expect(result.oneDollarBills).toBe(1)
         expect(result.quarters).toBe(3)
@@ -28,8 +29,9 @@ describe("Getting the correct change in return.", () => {
     
 
     //////////// ONE DOLLAR BILLS & BELOW //////////////
-    it("Should return 0 ten dollar bills, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
+    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(193)
+        expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(1)
         expect(result.quarters).toBe(3)
@@ -41,8 +43,9 @@ describe("Getting the correct change in return.", () => {
 
     //////////// QUARTERS & BELOW //////////////
 
-    it("Should return 0 ten dollar bills, 0 one dollar bills, 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
+    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
         const result = returnChange(44)
+        expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(1)
@@ -51,8 +54,9 @@ describe("Getting the correct change in return.", () => {
         expect(result.pennies).toBe(4)
         })
 
-    it("Should return 0 ten dollar bills, 0 one dollar bills, 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
+    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
         const result = returnChange(28)
+        expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(1)
@@ -62,8 +66,9 @@ describe("Getting the correct change in return.", () => {
     })
 
     //////////// DIMES & BELOW //////////////
-    it("Should return 0 ten dollar bills, 0 one dollar bills, 1 dime, 1 nickel, and 2 pennies.", () => {
+    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 dime, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(17)
+        expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)
@@ -74,8 +79,9 @@ describe("Getting the correct change in return.", () => {
 
 
     ////////////// NICKELS & BELOW //////////////
-    it("Should return 0 ten dollar bills, 0 one dollar bills, 1 nickel and 2 pennies", () => {
+    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 1 nickel and 2 pennies", () => {
         const result = returnChange(7)
+        expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)
@@ -87,8 +93,9 @@ describe("Getting the correct change in return.", () => {
     
     //////////// PENNIES //////////////
 
-    it("Should return 0 one dollar bills, 0 quarters, 0 dimes, 0 nickels, and 4 pennies.", () => {
+    it("Should return 0 twenty dollar bills, 0 ten dollar bills, 0 one dollar bills, 0 quarters, 0 dimes, 0 nickels, and 4 pennies.", () => {
         const result = returnChange(4)
+        expect(result.twentyDollarBills).toBe(0)
         expect(result.tenDollarBills).toBe(0)
         expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -2,9 +2,20 @@ const returnChange = require("../changeReturn")
 
 
 describe("Getting the correct change in return.", () => {
+
+    //////////// TEN DOLLAR BILLS & BELOW //////////////
+    it("Should return 1 ten dollar bill, 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
+        const result = returnChange(1193)
+        expect(result.tenDollarBills).toBe(1)
+        expect(result.oneDollarBills).toBe(1)
+        expect(result.quarters).toBe(3)
+        expect(result.dimes).toBe(1)
+        expect(result.nickels).toBe(1)
+        expect(result.pennies).toBe(3)
+        })
     
 
-    //////////// DOLLARS & BELOW //////////////
+    //////////// ONE DOLLAR BILLS & BELOW //////////////
     it("Should return 1 one dollar bill, 3 quarters, 1 dimes, 1 nickel, and 3 pennies.", () => {
         const result = returnChange(193)
         expect(result.oneDollarBills).toBe(1)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -5,7 +5,7 @@ describe("Getting the correct change in return.", () => {
 
     //////////// 28 Cents //////////////
     it("Should return 2 dimes, 1 nickel, and 3 pennies.", () => {
-        const result = returnChange(22)
+        const result = returnChange(28)
         expect(result.dimes).toBe(2)
         expect(result.nickels).toBe(1)
         expect(result.pennies).toBe(3)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -3,6 +3,19 @@ const returnChange = require("../changeReturn")
 
 describe("Getting the correct change in return.", () => {
 
+    //////////// FIFTY DOLLAR BILLS & BELOW //////////////
+    it("Should return 1 fifty dollar bill, 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
+        const result = returnChange(8267)
+        expect(result.fiftyDollarBills).toBe(1)
+        expect(result.twentyDollarBills).toBe(1)
+        expect(result.tenDollarBills).toBe(1)
+        expect(result.oneDollarBills).toBe(2)
+        expect(result.quarters).toBe(2)
+        expect(result.dimes).toBe(1)
+        expect(result.nickels).toBe(1)
+        expect(result.pennies).toBe(2)
+        })
+
     //////////// TWENTY DOLLAR BILLS & BELOW //////////////
     it("Should return 1 twenty dollar bill, 1 ten dollar bill, 2 one dollar bill, 2 quarters, 1 dimes, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(3267)

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -1,15 +1,15 @@
-const returnChange = require("../modules/coinReturns")
+const returnChange = require("../changeReturn")
 
 
 describe("Getting the correct change in return.", () => {
 
     ////////////// 22 Cents //////////////
-    it("Should return 2 dimes and 2 pennies.", () => {
-        const result = returnChange(22)
-        expect(result.dimes).toBe(2)
-        expect(result.nickels).toBe(0)
-        expect(result.pennies).toBe(2)
-    })
+    // it("Should return 2 dimes and 2 pennies.", () => {
+    //     const result = returnChange(22)
+    //     expect(result.dimes).toBe(2)
+    //     expect(result.nickels).toBe(0)
+    //     expect(result.pennies).toBe(2)
+    // })
 
 
     ////////////// 7 cents //////////////
@@ -17,6 +17,13 @@ describe("Getting the correct change in return.", () => {
         const result = returnChange(7)
         expect(result.nickels).toBe(1)
         expect(result.pennies).toBe(2)
+    })
+
+    ////////////// 14 cents //////////////
+    it("Should return 2 nickels and 4 pennies", () => {
+        const result = returnChange(14)
+        expect(result.nickels).toBe(2)
+        expect(result.pennies).toBe(4)
     })
 
     

--- a/__test__/change.test.js
+++ b/__test__/change.test.js
@@ -18,6 +18,7 @@ describe("Getting the correct change in return.", () => {
 
     it("Should return 1 quarter, 1 dimes, 1 nickel, and 4 pennies.", () => {
         const result = returnChange(44)
+        expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(1)
         expect(result.dimes).toBe(1)
         expect(result.nickels).toBe(1)
@@ -26,6 +27,7 @@ describe("Getting the correct change in return.", () => {
 
     it("Should return 1 quarter, 0 dimes, 0 nickels, and 3 pennies.", () => {
         const result = returnChange(28)
+        expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(1)
         expect(result.dimes).toBe(0)
         expect(result.nickels).toBe(0)
@@ -35,6 +37,7 @@ describe("Getting the correct change in return.", () => {
     //////////// DIMES & BELOW //////////////
     it("Should return 1 dime, 1 nickel, and 2 pennies.", () => {
         const result = returnChange(17)
+        expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)
         expect(result.dimes).toBe(1)
         expect(result.nickels).toBe(1)
@@ -45,6 +48,7 @@ describe("Getting the correct change in return.", () => {
     ////////////// NICKELS & BELOW //////////////
     it("Should return 1 nickel and 2 pennies", () => {
         const result = returnChange(7)
+        expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)
         expect(result.dimes).toBe(0)
         expect(result.nickels).toBe(1)
@@ -56,6 +60,7 @@ describe("Getting the correct change in return.", () => {
 
     it("Should return 4 pennies.", () => {
         const result = returnChange(4)
+        expect(result.oneDollarBills).toBe(0)
         expect(result.quarters).toBe(0)
         expect(result.dimes).toBe(0)
         expect(result.nickels).toBe(0)

--- a/changeReturn.js
+++ b/changeReturn.js
@@ -6,13 +6,25 @@ const returnChange = (amountGiven) => {
         pennies: 0
     }
     
-    if (amountGiven >= 5){
-        change.nickels += Math.floor((amountGiven/5))
-        change.pennies += amountGiven % 5
-    } else {
-        change.pennies += amountGiven
+    let changeLeft = amountGiven
+
+    const calculateChange = (changeLeft) => {
+        if (changeLeft >= 5){
+            change.nickels += Math.floor((changeLeft/5))
+            changeLeft -= change.nickels * 5
+            calculateChange(changeLeft)
+        } else {
+            change.pennies += changeLeft
+            changeLeft -= change.pennies
+        }
     }
+
+    if (changeLeft > 0) {
+        calculateChange(changeLeft)
+    }
+
     return change
+
 };
 
 module.exports = returnChange

--- a/changeReturn.js
+++ b/changeReturn.js
@@ -9,7 +9,11 @@ const returnChange = (amountGiven) => {
     let changeLeft = amountGiven
 
     const calculateChange = (changeLeft) => {
-        if (changeLeft >= 5){
+        if (changeLeft >= 10){
+            change.dimes += Math.floor((changeLeft/10))
+            changeLeft -= change.dimes * 10
+            calculateChange(changeLeft)
+        } else if (changeLeft >= 5){
             change.nickels += Math.floor((changeLeft/5))
             changeLeft -= change.nickels * 5
             calculateChange(changeLeft)

--- a/changeReturn.js
+++ b/changeReturn.js
@@ -1,6 +1,7 @@
 ////////////// Returns Change //////////////
 const returnChange = (amountGiven) => {
     let change = {
+        oneHundredDollarBills: 0,
         fiftyDollarBills: 0,
         twentyDollarBills: 0,
         tenDollarBills: 0,
@@ -14,7 +15,11 @@ const returnChange = (amountGiven) => {
     let changeLeft = amountGiven
 
     const calculateChange = (changeLeft) => {
-        if (changeLeft >= 5000){
+        if (changeLeft >= 10000){
+            change.oneHundredDollarBills += Math.floor((changeLeft/10000))
+            changeLeft -= change.oneHundredDollarBills * 10000
+            calculateChange(changeLeft)
+        } else if (changeLeft >= 5000){
             change.fiftyDollarBills += Math.floor((changeLeft/5000))
             changeLeft -= change.fiftyDollarBills * 5000
             calculateChange(changeLeft)

--- a/changeReturn.js
+++ b/changeReturn.js
@@ -1,6 +1,7 @@
 ////////////// Returns Change //////////////
 const returnChange = (amountGiven) => {
     let change = {
+        fiftyDollarBills: 0,
         twentyDollarBills: 0,
         tenDollarBills: 0,
         oneDollarBills: 0,
@@ -13,7 +14,11 @@ const returnChange = (amountGiven) => {
     let changeLeft = amountGiven
 
     const calculateChange = (changeLeft) => {
-        if (changeLeft >= 2000){
+        if (changeLeft >= 5000){
+            change.fiftyDollarBills += Math.floor((changeLeft/5000))
+            changeLeft -= change.fiftyDollarBills * 5000
+            calculateChange(changeLeft)
+        } else if (changeLeft >= 2000){
             change.twentyDollarBills += Math.floor((changeLeft/2000))
             changeLeft -= change.twentyDollarBills * 2000
             calculateChange(changeLeft)

--- a/changeReturn.js
+++ b/changeReturn.js
@@ -1,6 +1,7 @@
 ////////////// Returns Change //////////////
 const returnChange = (amountGiven) => {
     let change = {
+        tenDollarBills: 0,
         oneDollarBills: 0,
         quarters: 0,
         dimes: 0,
@@ -11,7 +12,11 @@ const returnChange = (amountGiven) => {
     let changeLeft = amountGiven
 
     const calculateChange = (changeLeft) => {
-        if (changeLeft >= 100){
+        if (changeLeft >= 1000){
+            change.tenDollarBills += Math.floor((changeLeft/1000))
+            changeLeft -= change.tenDollarBills * 1000
+            calculateChange(changeLeft)
+        } else if (changeLeft >= 100){
             change.oneDollarBills += Math.floor((changeLeft/100))
             changeLeft -= change.oneDollarBills * 100
             calculateChange(changeLeft)

--- a/changeReturn.js
+++ b/changeReturn.js
@@ -1,0 +1,19 @@
+////////////// Returns Change //////////////
+const returnChange = (amountGiven) => {
+    let change = {
+        dimes: 0,
+        nickels: 0,
+        pennies: 0
+    }
+    
+    if (amountGiven >= 5){
+        change.nickels += Math.floor((amountGiven/5))
+        change.pennies += amountGiven % 5
+    } else {
+        change.pennies += amountGiven
+    }
+    return change
+};
+
+module.exports = returnChange
+

--- a/changeReturn.js
+++ b/changeReturn.js
@@ -1,6 +1,7 @@
 ////////////// Returns Change //////////////
 const returnChange = (amountGiven) => {
     let change = {
+        twentyDollarBills: 0,
         tenDollarBills: 0,
         oneDollarBills: 0,
         quarters: 0,
@@ -12,7 +13,11 @@ const returnChange = (amountGiven) => {
     let changeLeft = amountGiven
 
     const calculateChange = (changeLeft) => {
-        if (changeLeft >= 1000){
+        if (changeLeft >= 2000){
+            change.twentyDollarBills += Math.floor((changeLeft/2000))
+            changeLeft -= change.twentyDollarBills * 2000
+            calculateChange(changeLeft)
+        } else if (changeLeft >= 1000){
             change.tenDollarBills += Math.floor((changeLeft/1000))
             changeLeft -= change.tenDollarBills * 1000
             calculateChange(changeLeft)

--- a/changeReturn.js
+++ b/changeReturn.js
@@ -1,6 +1,7 @@
 ////////////// Returns Change //////////////
 const returnChange = (amountGiven) => {
     let change = {
+        quarters: 0,
         dimes: 0,
         nickels: 0,
         pennies: 0
@@ -9,7 +10,11 @@ const returnChange = (amountGiven) => {
     let changeLeft = amountGiven
 
     const calculateChange = (changeLeft) => {
-        if (changeLeft >= 10){
+        if (changeLeft >= 25){
+            change.quarters += Math.floor((changeLeft/25))
+            changeLeft -= change.quarters * 25
+            calculateChange(changeLeft)
+        } else if (changeLeft >= 10){
             change.dimes += Math.floor((changeLeft/10))
             changeLeft -= change.dimes * 10
             calculateChange(changeLeft)

--- a/changeReturn.js
+++ b/changeReturn.js
@@ -1,6 +1,7 @@
 ////////////// Returns Change //////////////
 const returnChange = (amountGiven) => {
     let change = {
+        oneDollarBills: 0,
         quarters: 0,
         dimes: 0,
         nickels: 0,
@@ -10,7 +11,11 @@ const returnChange = (amountGiven) => {
     let changeLeft = amountGiven
 
     const calculateChange = (changeLeft) => {
-        if (changeLeft >= 25){
+        if (changeLeft >= 100){
+            change.oneDollarBills += Math.floor((changeLeft/100))
+            changeLeft -= change.oneDollarBills * 100
+            calculateChange(changeLeft)
+        } else if (changeLeft >= 25){
             change.quarters += Math.floor((changeLeft/25))
             changeLeft -= change.quarters * 25
             calculateChange(changeLeft)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A small app to calculate the amount of change and how many of each denomination given a specific input (USD).",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This branch includes the functionality and the testing of said functionality to take in a number in US dollar (multiplied by 100), and return the number of bills and coins it would require for change using the least number of each denomination as possible. I made a brief attempt to make it possible to input a number with a decimal like US currency is used in real life, but the Math functions aren't exact and return different decimals. If a front end were developed for this app, my initial MVP would take an input using decimals like it is used in real life, multiply it by 100, and then run it through the function.